### PR TITLE
Security patch, updating other subscriptions

### DIFF
--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,5 +1,6 @@
 class SubscriptionsController < ApplicationController
   before_action :set_subscription, only: [:edit, :update, :destroy, :pause]
+  before_action :validate_ownership, only: [:edit, :update, :destroy, :pause]
   before_action :check_subscription_limit, only: [:create]
 
   def index
@@ -63,6 +64,12 @@ class SubscriptionsController < ApplicationController
   def check_subscription_limit
     if current_user.over_subscription_limit?
       flash[:error] = "Sorry, only two subscriptions per user are allowed at this time."
+      redirect_to subscriptions_path
+    end
+  end
+
+  def validate_ownership
+    if current_user != @subscription.user
       redirect_to subscriptions_path
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,7 +7,7 @@ Rails.application.routes.draw do
 
   resources :users
   resources :verifications, only: [:edit, :update]
-  resources :subscriptions do
+  resources :subscriptions, only: [:index, :new, :edit, :update, :create, :destroy] do
     member do
       get 'pause', as: 'pause'
       get 'activate', as: 'activate'

--- a/spec/features/user_manages_subscription_spec.rb
+++ b/spec/features/user_manages_subscription_spec.rb
@@ -83,15 +83,26 @@ feature "User manages his or her subscription" do
     end
   end
 
-  scenario "updates his subscription successfully" do
-    subscription = create(:subscription, user_id: user.id)
-    visit subscriptions_path
-    click_link "Edit"
-    fill_in "Name", with: "Test"
-    select('Eastern', :from => 'subscription[time_zone]')
-    click_button "Update Subscription"
-    subscription.reload
-    expect(subscription.name).to eq "Test"
+  context "Updating Subscription" do
+    scenario "Cannot update other's subscription" do
+      user_2 = create(:user)
+      subscription_1= create(:subscription, user_id: user.id, name: "My subscription")
+      subscription_2 = create(:subscription, user_id: user_2.id, name: "Others subscription")
+      visit edit_subscription_path(subscription_2)
+      expect(page).to have_content(subscription_1.name)
+      expect(page).to_not have_content(subscription_2.name)
+    end
+
+    scenario "updates his own subscription successfully" do
+      subscription = create(:subscription, user_id: user.id)
+      visit subscriptions_path
+      click_link "Edit"
+      fill_in "Name", with: "Test"
+      select('Eastern', :from => 'subscription[time_zone]')
+      click_button "Update Subscription"
+      subscription.reload
+      expect(subscription.name).to eq "Test"
+    end
   end
 
   context "Subscription Deletion" do


### PR DESCRIPTION
Major security hole, patched and tested. user can no longer update someone else's subscriptions by changing the id in the browser.
